### PR TITLE
Fixed crucial typos

### DIFF
--- a/starter/03-CSS-Fundamentals/index.html
+++ b/starter/03-CSS-Fundamentals/index.html
@@ -118,13 +118,13 @@
             src="img/related-1.jpg"
             alt="Person programming"
             width="75"
-            width="75"
+            height="75"
           />
           <a href="#">How to Learn Web Development</a>
           <p>By Jonas Schmedtmann</p>
         </li>
         <li>
-          <img src="img/related-2.jpg" alt="Lightning" width="75" heigth="75" />
+          <img src="img/related-2.jpg" alt="Lightning" width="75" height="75" />
           <a href="#">The Unknown Powers of CSS</a>
           <p>By Jim Dillon</p>
         </li>


### PR DESCRIPTION
There were several attributes in which the 'height' spellings were wrong, moreover, some attributes of the img tag were written twice